### PR TITLE
perf：Fix HTML Encoding Issue in Magnet Links 🚀

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"log"
 	"math/rand"
@@ -435,7 +436,7 @@ func addTorrentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	magnet := request.Magnet
+	magnet := html.UnescapeString(request.Magnet)
 	if magnet == "" {
 		respondWithJSON(w, http.StatusBadRequest, map[string]string{"error": "No magnet link provided"})
 	}


### PR DESCRIPTION
On certain platforms (e.g., cilisousuo.com), the Magnet links copied by users are encoded in HTML. This causes the following issues:

Trackers Fail to Recognize Links: Due to the abnormal encoded format, trackers cannot parse the links properly.
Resource Not Found: Users may fail to locate or download the intended resources, which negatively impacts the user experience.