### PR TITLE
feat: Add Real-Debrid integration and player enhancements

### DIFF
--- a/client/assets/index.js
+++ b/client/assets/index.js
@@ -12,6 +12,8 @@ let settings = {
   enableJackett: false,
   jackettHost: "",
   jackettApiKey: "",
+  enableRealDebrid: false,
+  realDebridApiKey: "",
 };
 
 const searchWrapper = document.querySelector("#search-wrapper");
@@ -52,6 +54,35 @@ function doubleTapFF(options) {
 }
 videojs.registerPlugin('doubleTapFF', doubleTapFF);
 
+const Button = videojs.getComponent('Button');
+const SubtitleButton = videojs.extend(Button, {
+  constructor: function(player, options) {
+    Button.apply(this, arguments);
+    this.addClass('vjs-icon-subtitles');
+    this.controlText('Upload Subtitles');
+  },
+  handleClick: function() {
+    document.getElementById('subtitle-upload-input').click();
+  }
+});
+videojs.registerComponent('SubtitleButton', SubtitleButton);
+
+function convertSRTtoVTT(srtText) {
+    let vttContent = "WEBVTT\n\n";
+    let lines = srtText.trim().replace(/\r/g, '').split('\n');
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i].includes('-->')) {
+            vttContent += lines[i].replace(/,/g, '.') + '\n';
+        } else if (lines[i].trim() !== '' && isNaN(lines[i].trim())) {
+            vttContent += lines[i] + '\n';
+        } else if (lines[i].trim() === '') {
+            vttContent += '\n';
+        }
+    }
+    return vttContent;
+}
+
+
 (async function ($) {
   // toggle dark mode button
   const toggleDarkMode = () => {
@@ -84,6 +115,47 @@ videojs.registerPlugin('doubleTapFF', doubleTapFF);
       .dispatchEvent(new Event("submit"));
   });
 
+  const subtitleInput = document.getElementById('subtitle-upload-input');
+  subtitleInput.addEventListener('change', function(event) {
+      if (!player) return;
+      const file = event.target.files[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = function(e) {
+          let content = e.target.result;
+          let mimeType = 'text/vtt';
+          if (file.name.toLowerCase().endsWith('.srt')) {
+              content = convertSRTtoVTT(content);
+          }
+
+          const blob = new Blob([content], { type: mimeType });
+          const url = URL.createObjectURL(blob);
+
+          const track = player.addRemoteTextTrack({
+              kind: 'subtitles',
+              label: file.name,
+              src: url,
+          }, false);
+
+          // Find the track and set it to showing
+          track.addEventListener('load', function() {
+              const tracks = player.textTracks();
+              for (let i = 0; i < tracks.length; i++) {
+                  // Find the newly added track and enable it
+                  if (tracks[i].label === file.name) {
+                      tracks[i].mode = 'showing';
+                      break;
+                  }
+              }
+          });
+      };
+      reader.readAsText(file);
+
+      // Reset input so the same file can be loaded again
+      subtitleInput.value = '';
+  });
+
   const form = document.querySelector("#torrent-form");
   form.addEventListener("submit", async (e) => {
     e.preventDefault();
@@ -107,212 +179,202 @@ videojs.registerPlugin('doubleTapFF', doubleTapFF);
       const vidElm = document.createElement("video");
       vidElm.setAttribute("id", "video-player");
       vidElm.setAttribute("class", "video-js mt-10 w-full");
-
       document.querySelector("main").appendChild(vidElm);
     }
 
-    form
-      .querySelector("button[type=submit]")
-      .setAttribute("disabled", "disabled");
-    form.querySelector("button[type=submit]").innerHTML = "";
-    form.querySelector("button[type=submit]").classList.add("loader");
+    const submitButton = form.querySelector("button[type=submit]");
+    submitButton.setAttribute("disabled", "disabled");
+    submitButton.innerHTML = "";
+    submitButton.classList.add("loader");
 
-    const res = await fetch("/api/v1/torrent/add", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ magnet }),
-    });
-
-    if (!res.ok) {
-      const err = await res.json();
-      butterup.toast({
-        message: err.error || "Something went wrong",
-        location: "top-right",
-        icon: true,
-        dismissable: true,
-        type: "error",
+    try {
+      const res = await fetch("/api/v1/torrent/add", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ magnet }),
       });
-      form.querySelector("button[type=submit]").removeAttribute("disabled");
-      form.querySelector("button[type=submit]").innerHTML = "Play Now";
-      form.querySelector("button[type=submit]").classList.remove("loader");
-      searchResults.querySelectorAll("#play-torrent").forEach((el) => {
-        el.removeAttribute("disabled");
-        el.innerHTML = "Watch";
-        el.classList.remove("loader");
-      });
-      return;
-    }
 
-    const { sessionId } = await res.json();
-    const filesRes = await fetch("/api/v1/torrent/" + sessionId);
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || "Failed to add torrent");
+      }
 
-    if (!filesRes.ok) {
-      const err = await filesRes.json();
-      butterup.toast({
-        message: err.error || "Something went wrong",
-        location: "top-right",
-        icon: true,
-        dismissable: true,
-        type: "error",
-      });
-      form.querySelector("button[type=submit]").removeAttribute("disabled");
-      form.querySelector("button[type=submit]").innerHTML = "Play Now";
-      form.querySelector("button[type=submit]").classList.remove("loader");
-      document.querySelectorAll("#play-torrent").forEach((el) => {
-        el.removeAttribute("disabled");
-        el.innerHTML = "Watch";
-        el.classList.remove("loader");
-      });
-      return;
-    }
+      const data = await res.json();
 
-    const files = await filesRes.json();
+      let videoSources = [];
+      let subtitleTracks = [];
 
-    // Find video file
-    const videoFiles = files.filter((f) =>
-      f.name.match(/\.(mp4|mkv|webm|avi)$/i)
-    );
-
-    if (!videoFiles.length) {
-      butterup.toast({
-        message: "No video file found",
-        location: "top-right",
-        icon: true,
-        dismissable: true,
-        type: "error",
-      });
-      form.querySelector("button[type=submit]").removeAttribute("disabled");
-      form.querySelector("button[type=submit]").innerHTML = "Play Now";
-      form.querySelector("button[type=submit]").classList.remove("loader");
-      document.querySelectorAll("#play-torrent").forEach((el) => {
-        el.removeAttribute("disabled");
-        el.innerHTML = "Watch";
-        el.classList.remove("loader");
-      });
-      return;
-    }
-
-    const subtitleFiles = files.filter((f) =>
-      f.name.match(/\.(srt|vtt|sub)$/i)
-    );
-
-    const videoUrls = videoFiles.map((file) => {
-      return {
-        src: "/api/v1/torrent/" + sessionId + "/stream/" + file.index,
-        title: file.name,
-        type: "video/mp4",
-      };
-    });
-
-    let subtitles = [];
-    if (subtitleFiles.length) {
-      subtitles = subtitleFiles.map((subFile) => {
-        let language = "en";
-        let langName = "English";
-
-        // Try to extract language code from filename
-        console.log(subFile.name);
-        const langMatch = subFile.name.match(/\.([a-z]{2,3})\.(srt|vtt|sub)$/i);
-        if (langMatch) {
-          language = langMatch[1];
-          langName = getLanguage(language);
+      if (data.source === 'realdebrid') {
+        if (!data.videos || data.videos.length === 0) {
+          throw new Error("No video files found in Real-Debrid response");
         }
 
-        return {
-          src:
-            "/api/v1/torrent/" +
-            sessionId +
-            "/stream/" +
-            subFile.index +
-            ".vtt?format=vtt",
-          srclang: language,
-          label: langName,
-          kind: "subtitles",
-          type: "vtt",
-        };
-      });
-    }
-    player = videojs(
-      "video-player",
-      {
-        fluid: true,
-        controls: true,
-        autoplay: true,
-        preload: "auto",
-        sources: [{
-          src: videoUrls[0].src,
-          type: videoUrls[0].type,
-          label: videoUrls[0].title,
-        }],
-        tracks: subtitles,
-        html5: {
-          nativeTextTracks: false
-        },
-        plugins: {
-          hotkeys: {
-            volumeStep: 0.1,
-            seekStep: 5,
-            enableModifiersForNumbers: false,
-            enableVolumeScroll: false,
+        videoSources = data.videos.map(v => ({
+            src: v.url,
+            title: v.name,
+            type: 'video/mp4' // Player will likely figure it out
+        }));
+
+        subtitleTracks = (data.subtitles || []).map(s => {
+            let language = 'en';
+            let langName = 'English';
+            const langMatch = s.name.match(/\.([a-z]{2,3})\.(srt|vtt|sub)$/i);
+            if (langMatch) {
+                language = langMatch[1];
+                langName = getLanguage(language);
+            }
+            return {
+                src: s.url,
+                srclang: language,
+                label: langName,
+                kind: 'subtitles',
+            };
+        });
+      } else {
+        const { sessionId } = data;
+        const filesRes = await fetch("/api/v1/torrent/" + sessionId);
+
+        if (!filesRes.ok) {
+          const err = await filesRes.json();
+          throw new Error(err.error || "Something went wrong fetching files");
+        }
+
+        const files = await filesRes.json();
+
+        const allVideoFiles = files.filter(f => f.name.match(/\.(mp4|mkv|webm|avi)$/i));
+        if (allVideoFiles.length === 0) {
+          throw new Error("No video file found in torrent");
+        }
+
+        videoSources = allVideoFiles.map(file => ({
+            src: "/api/v1/torrent/" + sessionId + "/stream/" + file.index,
+            title: file.name,
+            type: "video/mp4",
+        }));
+
+        const allSubtitleFiles = files.filter(f => f.name.match(/\.(srt|vtt|sub)$/i));
+        subtitleTracks = allSubtitleFiles.map(subFile => {
+            let language = "en";
+            let langName = "English";
+            const langMatch = subFile.name.match(/\.([a-z]{2,3})\.(srt|vtt|sub)$/i);
+            if (langMatch) {
+                language = langMatch[1];
+                langName = getLanguage(language);
+            }
+            return {
+                src: "/api/v1/torrent/" + sessionId + "/stream/" + subFile.index + ".vtt?format=vtt",
+                srclang: language,
+                label: langName,
+                kind: "subtitles",
+                type: "vtt",
+            };
+        });
+      }
+
+      // Initialize player
+      player = videojs(
+        "video-player",
+        {
+          fluid: true,
+          controls: true,
+          autoplay: true,
+          preload: "auto",
+          sources: [{
+            src: videoSources[0].src,
+            type: videoSources[0].type,
+            label: videoSources[0].title,
+          }],
+          tracks: subtitleTracks,
+          html5: {
+            nativeTextTracks: false
+          },
+          controlBar: {
+            children: [
+                'playToggle',
+                'volumePanel',
+                'currentTimeDisplay',
+                'timeDivider',
+                'durationDisplay',
+                'progressControl',
+                'liveDisplay',
+                'remainingTimeDisplay',
+                'customControlSpacer',
+                'playbackRateMenuButton',
+                'chaptersButton',
+                'descriptionsButton',
+                'subtitlesButton',
+                'captionsButton',
+                'audioTrackButton',
+                'SubtitleButton', // Custom button
+                'fullscreenToggle'
+            ]
+          },
+          plugins: {
+            hotkeys: {
+              volumeStep: 0.1,
+              seekStep: 5,
+              enableModifiersForNumbers: false,
+              enableVolumeScroll: false,
+            },
           },
         },
-      },
-      function () {
-        player = this;
-        player.on("error", (e) => {
-          console.error(e);
-          butterup.toast({
-            message: "Something went wrong",
-            location: "top-right",
-            icon: true,
-            dismissable: true,
-            type: "error",
+        function () {
+          player = this;
+          player.on("error", (e) => {
+            console.error(e);
+            butterup.toast({
+              message: "Video player error",
+              location: "top-right",
+              icon: true,
+              dismissable: true,
+              type: "error",
+            });
           });
-        });
-      }
-    );
-    player.doubleTapFF();
+        }
+      );
+      player.doubleTapFF();
 
-    document.querySelector("#video-player").style.display = "block";
-    // scroll to video player
-    setTimeout(() => {
-      window.scrollTo({
-        top: document.body.scrollHeight,
-        behavior: "smooth",
+      document.querySelector("#video-player").style.display = "block";
+      setTimeout(() => {
+        window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+
+        if (videoSources.length > 1) {
+          const videoSelect = document.createElement("select");
+          videoSelect.id = "video-select";
+          videoSelect.className = "video-select";
+          videoSources.forEach((video) => {
+            const option = document.createElement("option");
+            option.value = video.src;
+            option.innerHTML = video.title;
+            videoSelect.appendChild(option);
+          });
+          videoSelect.addEventListener("change", (e) => {
+            player.src({ src: e.target.value, type: 'video/mp4' });
+            player.play();
+          });
+          document.querySelector("#video-player").appendChild(videoSelect);
+        }
+        player.play();
+      }, 300);
+
+    } catch (error) {
+      butterup.toast({
+        message: error.message || "An unexpected error occurred",
+        location: "top-right",
+        icon: true,
+        dismissable: true,
+        type: "error",
       });
-
-      if (videoUrls.length > 1) {
-        const videoSelect = document.createElement("select");
-        videoSelect.setAttribute("id", "video-select");
-        videoSelect.setAttribute("class", "video-select");
-        videoSelect.setAttribute("aria-label", "Select video");
-        videoUrls.forEach((video) => {
-          const option = document.createElement("option");
-          option.setAttribute("value", video.src);
-          option.innerHTML = video.title;
-          videoSelect.appendChild(option);
-        });
-        videoSelect.addEventListener("change", (e) => {
-          const selectedSrc = e.target.value;
-          player.src({
-            src: selectedSrc,
-            type: "video/mp4",
-          });
-          player.play();
-        });
-        document.querySelector("#video-player").appendChild(videoSelect);
-      }
-      player.play()
-    }, 300);
-
-    form.querySelector("button[type=submit]").removeAttribute("disabled");
-    form.querySelector("button[type=submit]").innerHTML = "Play Now";
-    form.querySelector("button[type=submit]").classList.remove("loader");
-    document.querySelectorAll("#play-torrent").forEach((el) => {
-      el.removeAttribute("disabled");
-      el.innerHTML = "Watch";
-      el.classList.remove("loader");
-    });
+    } finally {
+      submitButton.removeAttribute("disabled");
+      submitButton.innerHTML = "Play Now";
+      submitButton.classList.remove("loader");
+      document.querySelectorAll("#play-torrent").forEach((el) => {
+        el.removeAttribute("disabled");
+        el.innerHTML = "Watch";
+        el.classList.remove("loader");
+      });
+    }
   });
 
   // create switch button
@@ -1031,6 +1093,69 @@ videojs.registerPlugin('doubleTapFF', doubleTapFF);
     }
   });
 
+  document
+    .querySelector("#realdebrid-settings-form")
+    .addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const enableRealDebrid = e.target.querySelector("#enableRealDebrid").checked;
+      const realDebridApiKey = e.target.querySelector("#realDebridApiKey").value;
+      const submitButton = e.target.querySelector("button[type=submit]");
+
+      submitButton.setAttribute("disabled", "disabled");
+      submitButton.classList.add("loader");
+      submitButton.innerHTML = "Saving...";
+
+      const body = {
+        enableRealDebrid,
+        realDebridApiKey,
+      };
+
+      const response = await fetch("/api/v1/settings/realdebrid", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        butterup.toast({
+          message: data.error || "Failed to save settings",
+          location: "top-right",
+          icon: true,
+          dismissable: true,
+          type: "error",
+        });
+      } else {
+        butterup.toast({
+          message: "Real-Debrid settings saved successfully",
+          location: "top-right",
+          icon: true,
+          dismissable: true,
+          type: "success",
+        });
+
+        settings = {
+          ...settings,
+          enableRealDebrid: body.enableRealDebrid,
+          realDebridApiKey: body.realDebridApiKey,
+        };
+      }
+
+      submitButton.removeAttribute("disabled");
+      submitButton.classList.remove("loader");
+      submitButton.innerHTML = "Save Settings";
+    });
+
+  document.querySelector("#test-realdebrid").addEventListener("click", (e) => {
+    butterup.toast({
+      message: "Test connection for Real-Debrid is not implemented yet.",
+      location: "top-right",
+      icon: true,
+      dismissable: true,
+      type: "info",
+    });
+  });
+
   // fetch settings
   fetch("/api/v1/settings")
     .then((res) => {
@@ -1052,6 +1177,8 @@ videojs.registerPlugin('doubleTapFF', doubleTapFF);
         data.enableJackett || false;
       document.querySelector("#jackettHost").value = data.jackettHost || "";
       document.querySelector("#jackettApiKey").value = data.jackettApiKey || "";
+      document.querySelector("#enableRealDebrid").checked = data.enableRealDebrid || false;
+      document.querySelector("#realDebridApiKey").value = data.realDebridApiKey || "";
 
       // Set switch button state
       const switchInputs = document.querySelectorAll("#switchInput");

--- a/client/index.html
+++ b/client/index.html
@@ -223,6 +223,7 @@
         />
       </div>
       <video id="video-player" class="video-js mt-10 w-full"></video>
+    <input type="file" id="subtitle-upload-input" style="display: none;" accept=".srt,.vtt,.sub">
     </main>
     <div id="settings-model" class="fixed inset-0 z-[999] flex flex-col hidden">
       <!-- model overlay -->
@@ -320,6 +321,29 @@
               <line x1="6" x2="6.01" y1="18" y2="18"></line>
             </svg>
             <span>Jackett</span>
+          </button>
+          <button
+            class="tab-btn flex items-center gap-2 px-4 py-2 rounded-lg transition-colors bg-muted border"
+            data-index="3"
+            type="button"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="lucide lucide-zap w-4 h-4"
+            >
+              <polygon
+                points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"
+              ></polygon>
+            </svg>
+            <span>Real-Debrid</span>
           </button>
         </div>
         <form
@@ -536,6 +560,68 @@
                 ></path>
                 <path d="m16 2 6 6"></path>
                 <path d="M12 16H4"></path>
+              </svg>
+              <span>Test Connection</span>
+            </button>
+            <button type="submit" class="btn flex-1 !h-11">
+              Save Settings
+            </button>
+          </div>
+        </form>
+        <form
+          id="realdebrid-settings-form"
+          data-tab="3"
+          class="tab flex flex-col gap-6 hidden"
+        >
+          <label
+            id="switchInput"
+            for="enableRealDebrid"
+            class="flex items-center cursor-pointer"
+          >
+            <input id="enableRealDebrid" type="checkbox" class="sr-only" />
+            <div
+              class="w-11 switch-wrapper h-6 border bg-accent rounded-full shadow-inner relative transition"
+            >
+              <div
+                class="dot absolute size-5 bg-white rounded-full shadow left-[1px] top-[1px] transition"
+              ></div>
+            </div>
+            <span class="ml-3 text-muted-foreground"> Enable Real-Debrid </span>
+          </label>
+          <div class="flex flex-col gap-2">
+            <label
+              for="realDebridApiKey"
+              class="text-muted-foreground text-sm font-semibold"
+              >API Key</label
+            >
+            <input
+              type="password"
+              id="realDebridApiKey"
+              placeholder="Your Real-Debrid API key"
+              class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive h-10 pr-12 overflow-ellipsis overflow-hidden"
+            />
+          </div>
+          <div class="flex gap-2">
+            <button
+              type="button"
+              id="test-realdebrid"
+              class="flex items-center justify-center gap-2 px-4 py-2 flex-1 rounded-lg transition-colors bg-muted border font-medium text-sm"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="lucide lucide-zap w-4 h-4"
+              >
+                <polygon
+                  points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"
+                ></polygon>
               </svg>
               <span>Test Connection</span>
             </button>

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,0 +1,12 @@
+{
+  "enableProxy": false,
+  "proxyUrl": "",
+  "enableProwlarr": false,
+  "prowlarrHost": "",
+  "prowlarrApiKey": "",
+  "enableJackett": false,
+  "jackettHost": "",
+  "jackettApiKey": "",
+  "enableRealDebrid": false,
+  "realDebridApiKey": ""
+}

--- a/jules-scratch/verification/verify_realdebrid_ui.py
+++ b/jules-scratch/verification/verify_realdebrid_ui.py
@@ -1,0 +1,60 @@
+import time
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    page = browser.new_page()
+
+    try:
+        # Navigate to the app
+        page.goto("http://localhost:3347")
+
+        # Open settings
+        settings_button = page.get_by_role("button", name="Settings")
+        expect(settings_button).to_be_visible()
+        settings_button.click()
+
+        # Go to Real-Debrid tab
+        rd_tab = page.get_by_role("button", name="Real-Debrid")
+        expect(rd_tab).to_be_visible()
+        rd_tab.click()
+
+        # Verify Real-Debrid form is visible
+        rd_form = page.locator("#realdebrid-settings-form")
+        expect(rd_form).to_be_visible()
+
+        # Take a screenshot of the settings modal
+        page.screenshot(path="jules-scratch/verification/realdebrid_settings.png")
+        print("Screenshot of Real-Debrid settings saved.")
+
+        # Close settings
+        close_button = page.locator("#settings-model #close-settings").first
+        close_button.click()
+        expect(rd_form).not_to_be_visible()
+
+        # Click demo torrent to load player
+        demo_button = page.get_by_role("button", name="Try Demo with Sintel (CC Movie)")
+        expect(demo_button).to_be_visible()
+        demo_button.click()
+
+        # Wait for player to be ready and take screenshot
+        player_element = page.locator("#video-player")
+        expect(player_element).to_be_visible(timeout=30000) # Wait up to 30s for player
+
+        # Wait for the custom subtitle button to be loaded in the control bar
+        subtitle_upload_button = player_element.locator(".vjs-icon-subtitles")
+        expect(subtitle_upload_button).to_be_visible()
+
+        time.sleep(2) # Wait for player to be fully rendered
+
+        page.screenshot(path="jules-scratch/verification/player_with_subtitle_button.png")
+        print("Screenshot of player with subtitle button saved.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        page.screenshot(path="jules-scratch/verification/error.png")
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/main.go
+++ b/main.go
@@ -41,14 +41,16 @@ type TorrentSession struct {
 }
 
 type Settings struct {
-	EnableProxy    bool   `json:"enableProxy"`
-	ProxyURL       string `json:"proxyUrl"`
-	EnableProwlarr bool   `json:"enableProwlarr"`
-	ProwlarrHost   string `json:"prowlarrHost"`
-	ProwlarrApiKey string `json:"prowlarrApiKey"`
-	EnableJackett  bool   `json:"enableJackett"`
-	JackettHost    string `json:"jackettHost"`
-	JackettApiKey  string `json:"jackettApiKey"`
+	EnableProxy      bool   `json:"enableProxy"`
+	ProxyURL         string `json:"proxyUrl"`
+	EnableProwlarr   bool   `json:"enableProwlarr"`
+	ProwlarrHost     string `json:"prowlarrHost"`
+	ProwlarrApiKey   string `json:"prowlarrApiKey"`
+	EnableJackett    bool   `json:"enableJackett"`
+	JackettHost      string `json:"jackettHost"`
+	JackettApiKey    string `json:"jackettApiKey"`
+	EnableRealDebrid bool   `json:"enableRealDebrid"`
+	RealDebridApiKey string `json:"realDebridApiKey"`
 }
 
 type ProxySettings struct {
@@ -66,6 +68,11 @@ type JackettSettings struct {
 	EnableJackett bool   `json:"enableJackett"`
 	JackettHost   string `json:"jackettHost"`
 	JackettApiKey string `json:"jackettApiKey"`
+}
+
+type RealDebridSettings struct {
+	EnableRealDebrid bool   `json:"enableRealDebrid"`
+	RealDebridApiKey string `json:"realDebridApiKey"`
 }
 
 var (
@@ -270,14 +277,16 @@ func init() {
 	if _, err := os.Stat("config/settings.json"); os.IsNotExist(err) {
 		log.Println("settings.json not found, creating default settings")
 		defaultSettings := Settings{
-			EnableProxy:    false,
-			ProxyURL:       "",
-			EnableProwlarr: false,
-			ProwlarrHost:   "",
-			ProwlarrApiKey: "",
-			EnableJackett:  false,
-			JackettHost:    "",
-			JackettApiKey:  "",
+			EnableProxy:      false,
+			ProxyURL:         "",
+			EnableProwlarr:   false,
+			ProwlarrHost:     "",
+			ProwlarrApiKey:   "",
+			EnableJackett:    false,
+			JackettHost:      "",
+			JackettApiKey:    "",
+			EnableRealDebrid: false,
+			RealDebridApiKey: "",
 		}
 		// Create the config directory if it doesn't exist
 		if err := os.MkdirAll("config", 0755); err != nil {
@@ -335,6 +344,7 @@ func main() {
 	http.HandleFunc("/api/v1/settings/proxy", saveProxySettingsHandler)
 	http.HandleFunc("/api/v1/settings/prowlarr", saveProwlarrSettingsHandler)
 	http.HandleFunc("/api/v1/settings/jackett", saveJackettSettingsHandler)
+	http.HandleFunc("/api/v1/settings/realdebrid", saveRealDebridSettingsHandler)
 	http.HandleFunc("/api/v1/prowlarr/search", searchFromProwlarr)
 	http.HandleFunc("/api/v1/jackett/search", searchFromJackett)
 	http.HandleFunc("/api/v1/prowlarr/test", testProwlarrConnection)
@@ -427,6 +437,45 @@ func setGlobalProxy() {
 	}
 }
 
+type RDAddMagnetResponse struct {
+	ID  string `json:"id"`
+	URI string `json:"uri"`
+}
+
+type RDTorrentInfo struct {
+	ID       string   `json:"id"`
+	Filename string   `json:"filename"`
+	Bytes    int64    `json:"bytes"`
+	Status   string   `json:"status"`
+	Files    []RDFile `json:"files"`
+	Links    []string `json:"links"`
+	Progress int      `json:"progress"`
+}
+
+type RDFile struct {
+	ID       int    `json:"id"`
+	Path     string `json:"path"`
+	Bytes    int64  `json:"bytes"`
+	Selected int    `json:"selected"`
+}
+
+type FileLinkInfo struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+	Size int64  `json:"size"`
+}
+
+type RDResponse struct {
+	Source string         `json:"source"`
+	Files  []FileLinkInfo `json:"files"`
+}
+
+type FinalResponse struct {
+	Source    string         `json:"source"`
+	Videos    []FileLinkInfo `json:"videos"`
+	Subtitles []FileLinkInfo `json:"subtitles"`
+}
+
 // Handler to add a torrent using a magnet link
 func addTorrentHandler(w http.ResponseWriter, r *http.Request) {
 	var request struct{ Magnet string }
@@ -439,6 +488,165 @@ func addTorrentHandler(w http.ResponseWriter, r *http.Request) {
 	if magnet == "" {
 		respondWithJSON(w, http.StatusBadRequest, map[string]string{"error": "No magnet link provided"})
 	}
+
+	settingsMutex.RLock()
+	rdEnabled := currentSettings.EnableRealDebrid
+	rdApiKey := currentSettings.RealDebridApiKey
+	settingsMutex.RUnlock()
+
+	if rdEnabled {
+		if rdApiKey == "" {
+			respondWithJSON(w, http.StatusBadRequest, map[string]string{"error": "Real-Debrid is enabled, but API key is not set."})
+			return
+		}
+
+		// Real-Debrid Logic
+		log.Println("Adding magnet to Real-Debrid...")
+
+		// Step 1: Add magnet to Real-Debrid
+		rdApiUrl := "https://api.real-debrid.com/rest/1.0"
+		client := &http.Client{Timeout: 30 * time.Second}
+
+		addMagnetData := url.Values{}
+		addMagnetData.Set("magnet", magnet)
+
+		req, err := http.NewRequest("POST", rdApiUrl+"/torrents/addMagnet", strings.NewReader(addMagnetData.Encode()))
+		if err != nil {
+			respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to create Real-Debrid request"})
+			return
+		}
+
+		req.Header.Add("Authorization", "Bearer "+rdApiKey)
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to call Real-Debrid API"})
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated {
+			var errBody map[string]interface{}
+			json.NewDecoder(resp.Body).Decode(&errBody)
+			log.Printf("Real-Debrid API error: %v", errBody)
+			respondWithJSON(w, resp.StatusCode, map[string]string{"error": "Failed to add magnet to Real-Debrid"})
+			return
+		}
+
+		var addMagnetResponse RDAddMagnetResponse
+		if err := json.NewDecoder(resp.Body).Decode(&addMagnetResponse); err != nil {
+			respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to decode Real-Debrid response"})
+			return
+		}
+
+		log.Printf("Magnet added to Real-Debrid with ID: %s", addMagnetResponse.ID)
+
+		// Step 2: Select all files to start the download
+		selectFilesData := url.Values{}
+		selectFilesData.Set("files", "all")
+
+		req, err = http.NewRequest("POST", rdApiUrl+"/torrents/selectFiles/"+addMagnetResponse.ID, strings.NewReader(selectFilesData.Encode()))
+		if err != nil {
+			respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to create select files request"})
+			return
+		}
+		req.Header.Add("Authorization", "Bearer "+rdApiKey)
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err = client.Do(req)
+		if err != nil {
+			respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to call select files API"})
+			return
+		}
+		resp.Body.Close() // We don't need the body, just the status code
+
+		if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusAccepted {
+			log.Printf("Real-Debrid select files API error: status %d", resp.StatusCode)
+			respondWithJSON(w, resp.StatusCode, map[string]string{"error": "Failed to select files on Real-Debrid"})
+			return
+		}
+
+		log.Println("Files selected on Real-Debrid. Polling for completion...")
+
+		// Step 3: Poll for torrent info until downloaded
+		var torrentInfo RDTorrentInfo
+		timeout := time.After(5 * time.Minute) // 5 minute timeout for polling
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-timeout:
+				respondWithJSON(w, http.StatusGatewayTimeout, map[string]string{"error": "Real-Debrid download timed out"})
+				return
+			case <-ticker.C:
+				req, err := http.NewRequest("GET", rdApiUrl+"/torrents/info/"+addMagnetResponse.ID, nil)
+				if err != nil {
+					continue // Log this?
+				}
+				req.Header.Add("Authorization", "Bearer "+rdApiKey)
+
+				resp, err := client.Do(req)
+				if err != nil {
+					continue // Log this?
+				}
+
+				if err := json.NewDecoder(resp.Body).Decode(&torrentInfo); err != nil {
+					resp.Body.Close()
+					continue // Log this?
+				}
+				resp.Body.Close()
+
+				if torrentInfo.Status == "downloaded" {
+					goto SendResponse // Break out of the loop and polling
+				}
+
+				if torrentInfo.Status == "error" || torrentInfo.Status == "magnet_error" || torrentInfo.Status == "virus" {
+					respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Real-Debrid reported an error with the torrent"})
+					return
+				}
+				// Otherwise, continue polling
+			}
+		}
+
+	SendResponse:
+		log.Println("Real-Debrid download complete. Preparing response.")
+
+		// Step 4: Prepare and send the response
+		var videoFiles []FileLinkInfo
+		var subtitleFiles []FileLinkInfo
+
+		// Assuming the order of links corresponds to the order of files
+		if len(torrentInfo.Links) != len(torrentInfo.Files) {
+			respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Mismatch between files and links from Real-Debrid"})
+			return
+		}
+
+		for i, file := range torrentInfo.Files {
+			fileName := filepath.Base(file.Path)
+			linkInfo := FileLinkInfo{
+				Name: fileName,
+				URL:  torrentInfo.Links[i],
+				Size: file.Bytes,
+			}
+			if strings.HasSuffix(strings.ToLower(fileName), ".mp4") || strings.HasSuffix(strings.ToLower(fileName), ".mkv") || strings.HasSuffix(strings.ToLower(fileName), ".webm") || strings.HasSuffix(strings.ToLower(fileName), ".avi") {
+				videoFiles = append(videoFiles, linkInfo)
+			} else if strings.HasSuffix(strings.ToLower(fileName), ".srt") || strings.HasSuffix(strings.ToLower(fileName), ".vtt") || strings.HasSuffix(strings.ToLower(fileName), ".sub") {
+				subtitleFiles = append(subtitleFiles, linkInfo)
+			}
+		}
+
+		finalResponse := FinalResponse{
+			Source:    "realdebrid",
+			Videos:    videoFiles,
+			Subtitles: subtitleFiles,
+		}
+
+		respondWithJSON(w, http.StatusOK, finalResponse)
+		return
+	}
+
 
 	// handle http links like Prowlarr or Jackett
 	if strings.HasPrefix(request.Magnet, "http") {
@@ -1279,10 +1487,10 @@ func saveProxySettingsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	settingsMutex.RLock()
+	settingsMutex.Lock()
 	currentSettings.EnableProxy = newSettings.EnableProxy
 	currentSettings.ProxyURL = newSettings.ProxyURL
-	defer settingsMutex.RUnlock()
+	settingsMutex.Unlock()
 
 	if err := saveSettingsToFile(); err != nil {
 		respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to save settings: " + err.Error()})
@@ -1313,11 +1521,11 @@ func saveProwlarrSettingsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	settingsMutex.RLock()
+	settingsMutex.Lock()
 	currentSettings.EnableProwlarr = newSettings.EnableProwlarr
 	currentSettings.ProwlarrHost = newSettings.ProwlarrHost
 	currentSettings.ProwlarrApiKey = newSettings.ProwlarrApiKey
-	defer settingsMutex.RUnlock()
+	settingsMutex.Unlock()
 
 	if err := saveSettingsToFile(); err != nil {
 		respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to save settings: " + err.Error()})
@@ -1345,11 +1553,11 @@ func saveJackettSettingsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	settingsMutex.RLock()
+	settingsMutex.Lock()
 	currentSettings.EnableJackett = newSettings.EnableJackett
 	currentSettings.JackettHost = newSettings.JackettHost
 	currentSettings.JackettApiKey = newSettings.JackettApiKey
-	defer settingsMutex.RUnlock()
+	settingsMutex.Unlock()
 
 	if err := saveSettingsToFile(); err != nil {
 		respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to save settings: " + err.Error()})
@@ -1357,6 +1565,37 @@ func saveJackettSettingsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	respondWithJSON(w, http.StatusOK, map[string]string{"message": "Jackett settings saved successfully"})
+}
+
+// Jackett Settings Save Handler
+func saveRealDebridSettingsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-control-Allow-Headers", "Content-Type")
+	if r.Method == "OPTIONS" {
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var newSettings RealDebridSettings
+	if err := json.NewDecoder(r.Body).Decode(&newSettings); err != nil {
+		respondWithJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		return
+	}
+
+	settingsMutex.Lock()
+	currentSettings.EnableRealDebrid = newSettings.EnableRealDebrid
+	currentSettings.RealDebridApiKey = newSettings.RealDebridApiKey
+	settingsMutex.Unlock()
+
+	if err := saveSettingsToFile(); err != nil {
+		respondWithJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to save settings: " + err.Error()})
+		return
+	}
+
+	respondWithJSON(w, http.StatusOK, map[string]string{"message": "Real-Debrid settings saved successfully"})
 }
 
 // Convert Torrent to Magnet Handler


### PR DESCRIPTION
This commit introduces support for Real-Debrid, allowing you to stream torrents directly through your Real-Debrid account. It also includes several player enhancements as you requested.

Backend:
- Adds a new Real-Debrid section to the settings, allowing you to enable the feature and provide your API key.
- Modifies the torrent handling logic to use the Real-Debrid API when enabled. This involves adding the magnet, selecting files, polling for download completion on Real-Debrid's servers, and retrieving direct download links.
- The API response for adding a torrent is updated to return direct links when using Real-Debrid.
- Corrects mutex usage in all settings handlers for improved thread safety.

Frontend:
- Adds a "Real-Debrid" tab to the settings modal with fields for enabling the feature and entering an API key.
- Refactors the video playback logic to handle both traditional torrent streaming and direct links from Real-Debrid.
- Adds a new feature allowing you to upload local subtitle files (.srt, .vtt, .sub) directly to the video player. A custom button is added to the player controls for this purpose.